### PR TITLE
Listen to generic "level" event

### DIFF
--- a/dim-with-me.app.groovy
+++ b/dim-with-me.app.groovy
@@ -81,6 +81,7 @@ def installed()
 	subscribe(masters, "switch.off", switchOffHandler)
 	subscribe(masters, "switch.setLevel", switchSetLevelHandler)
 	subscribe(masters, "switch", switchSetLevelHandler)
+	subscribe(masters, "level", switchSetLevelHandler)
 }
 
 def updated()
@@ -90,6 +91,7 @@ def updated()
 	subscribe(masters, "switch.off", switchOffHandler)
 	subscribe(masters, "switch.setLevel", switchSetLevelHandler)
 	subscribe(masters, "switch", switchSetLevelHandler)
+	subscribe(masters, "level", switchSetLevelHandler)
 	log.info "subscribed to all of switches events"
 }
 


### PR DESCRIPTION
This event is fired by the ["Z-Wave Dimmer Switch Generic"](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy#L121) device handler.

The "switch" listener might actually be incorrect, because that value will be "on" or "off", but there may be other device types that are firing the dimmer event that way.